### PR TITLE
[TASK:PPC1B000] Persist client register step, add form validations/masks, and show loading spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^19.2.1",
         "react-country-flag": "^3.1.0",
         "react-dom": "^19.2.1",
+        "react-loader-spinner": "^8.0.0",
         "react-select": "^5.10.2",
         "sass": "^1.91.0",
         "swiper": "^11.2.10"
@@ -1905,6 +1906,21 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
       "license": "MIT"
     },
     "node_modules/@emotion/memoize": {
@@ -4023,6 +4039,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
+    },
     "node_modules/@types/through": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
@@ -5272,6 +5294,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001739",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
@@ -5570,6 +5601,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -5585,6 +5625,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -9806,7 +9857,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -9928,6 +9978,23 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-loader-spinner": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-8.0.0.tgz",
+      "integrity": "sha512-Us+bM4Jb3ae5dcLF0owFAML2kRzBbqnAODjV+dNIG1TbErr4mj/nhAqDjLWsu4PH3txei5S5tQklI0dpcyTO0A==",
+      "license": "MIT",
+      "dependencies": {
+        "styled-components": "^6.1.19",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0 <20.0.0",
+        "react-dom": ">=17.0.0 <20.0.0"
+      }
     },
     "node_modules/react-select": {
       "version": "5.10.2",
@@ -10447,6 +10514,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -10861,6 +10934,80 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -11017,6 +11164,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^19.2.1",
     "react-country-flag": "^3.1.0",
     "react-dom": "^19.2.1",
+    "react-loader-spinner": "^8.0.0",
     "react-select": "^5.10.2",
     "sass": "^1.91.0",
     "swiper": "^11.2.10"

--- a/src/app/client-register/components/AddressForm/index.tsx
+++ b/src/app/client-register/components/AddressForm/index.tsx
@@ -1,28 +1,85 @@
 "use client";
 
+import React from "react";
 import PrimaryButton from "@/components/Buttons/PrimaryButton";
 import SecondaryButton from "@/components/Buttons/SecondaryButton";
 import CountryCodeSelect from "@/components/CountryCodeSelect";
 import { CustomCheckbox } from "@/components/CustomCheckbox";
 import InputField from "@/components/InputField";
-import React from "react";
+
+import { formatCEP } from "@/utils/input-formatting";
+import { isRequired, validateCEP } from "@/utils/inputs-validation";
+
+import { useRegister } from "../../context/RegisterContext";
 
 type AddressFormProps = {
   onNext: () => void;
   onBack: () => void;
 };
 
-export default function AddressForm({ onNext, onBack }: AddressFormProps) {
-  const [countryName, setCountryName] = React.useState("brazil");
-  const [noNumber, setNoNumber] = React.useState(false);
+interface FieldErrors {
+  zipCode?: string;
+  state?: string;
+  city?: string;
+  district?: string;
+  street?: string;
+  number?: string;
+  complement?: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onNext();
+export default function AddressForm({ onNext, onBack }: AddressFormProps) {
+  const { data, updateNested } = useRegister();
+  const address = data.address;
+
+  const formRef = React.useRef<HTMLFormElement>(null);
+  const [validationErrors, setValidationErrors] = React.useState<FieldErrors>(
+    {}
+  );
+
+  const isComplementRequired = address.noNumber;
+
+  const handleValidationChange = (
+    field: keyof FieldErrors,
+    error: string | undefined
+  ) => {
+    setValidationErrors((prev) => ({ ...prev, [field]: error }));
+  };
+
+  const isFormValid = React.useMemo(() => {
+    const hasErrors = Object.values(validationErrors).some(Boolean);
+
+    const filled =
+      address.zipCode.trim() !== "" &&
+      address.countryName.trim() !== "" &&
+      address.state.trim() !== "" &&
+      address.city.trim() !== "" &&
+      address.district.trim() !== "" &&
+      address.street.trim() !== "";
+
+    const numberOk = address.noNumber || address.number.trim() !== "";
+    const complementOk =
+      !isComplementRequired || address.complement.trim() !== "";
+
+    return !hasErrors && filled && numberOk && complementOk;
+  }, [validationErrors, address, isComplementRequired]);
+
+  const handleSubmit = () => {
+    formRef.current?.reportValidity();
+
+    if (isComplementRequired && !address.complement.trim()) {
+      handleValidationChange("complement", isRequired(address.complement));
+    }
+
+    if (isFormValid) {
+      onNext();
+    } else {
+      console.log("Formulário de Endereço inválido:", validationErrors);
+    }
   };
 
   return (
     <div className="flex flex-col gap-12 mb-10">
+      {/* Cabeçalho */}
       <div className="flex flex-col gap-2">
         <h1 className="text-2xl font-bold text-black">Endereço</h1>
         <p className="text-lg lg:text-xs 2xl:text-sm">
@@ -30,70 +87,151 @@ export default function AddressForm({ onNext, onBack }: AddressFormProps) {
           atendimento mais completo.
         </p>
       </div>
+
+      {/* Formulário */}
       <div className="flex flex-col gap-6">
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        <form
+          ref={formRef}
+          onSubmit={(e) => e.preventDefault()}
+          className="flex flex-col gap-6"
+        >
+          {/* CEP + País */}
           <div className="flex w-full flex-row gap-4">
             <InputField
               className="w-full"
               label="Código postal"
               type="text"
               placeholder="XXXXX-XXX"
+              value={address.zipCode}
+              onChange={(v) =>
+                updateNested("address", { zipCode: formatCEP(v) })
+              }
+              required
+              customValidator={validateCEP}
+              onValidationChange={(err) =>
+                handleValidationChange("zipCode", err)
+              }
+              errorMessage={validationErrors.zipCode}
             />
+
             <CountryCodeSelect
               mode="country"
               label="País"
-              value={countryName}
-              onChange={setCountryName}
+              value={address.countryName}
+              onChange={(v) => updateNested("address", { countryName: v })}
             />
           </div>
+
+          {/* Estado */}
           <InputField
             label="Estado/Província"
             placeholder="Digite o estado/província"
+            value={address.state}
+            onChange={(v) => updateNested("address", { state: v })}
+            required
+            onValidationChange={(err) => handleValidationChange("state", err)}
+            errorMessage={validationErrors.state}
           />
 
+          {/* Cidade */}
           <InputField
             label="Cidade"
             type="text"
             placeholder="Digite a cidade"
+            value={address.city}
+            onChange={(v) => updateNested("address", { city: v })}
+            required
+            onValidationChange={(err) => handleValidationChange("city", err)}
+            errorMessage={validationErrors.city}
           />
 
+          {/* Distrito */}
           <InputField
             label="Bairro/Distrito"
             type="text"
             placeholder="Digite o bairro/distrito"
+            value={address.district}
+            onChange={(v) => updateNested("address", { district: v })}
+            required
+            onValidationChange={(err) =>
+              handleValidationChange("district", err)
+            }
+            errorMessage={validationErrors.district}
           />
 
           <div className="flex flex-col gap-3 items-end w-full">
             <div className="flex w-full flex-row gap-4">
               <InputField
-                className="w-full"
+                className="flex-4/5"
                 label="Rua"
                 type="text"
                 placeholder="Digite a rua"
+                value={address.street}
+                onChange={(v) => updateNested("address", { street: v })}
+                required
+                onValidationChange={(err) =>
+                  handleValidationChange("street", err)
+                }
+                errorMessage={validationErrors.street}
               />
 
               <InputField
-                className="w-full"
+                className="flex-1/5"
                 label="N°"
                 type="number"
                 placeholder="XXX"
+                value={address.number}
+                onChange={(v) => updateNested("address", { number: v })}
+                isDisabled={address.noNumber}
+                required={!address.noNumber}
+                onValidationChange={(err) =>
+                  handleValidationChange("number", err)
+                }
+                errorMessage={validationErrors.number}
               />
             </div>
+
             <CustomCheckbox
               label="Endereço sem número"
-              checked={noNumber}
-              onChange={setNoNumber}
+              checked={address.noNumber}
+              onChange={(checked) => {
+                updateNested("address", { noNumber: checked });
+
+                handleValidationChange("number", undefined);
+
+                if (checked) {
+                  handleValidationChange(
+                    "complement",
+                    isRequired(address.complement)
+                  );
+                } else {
+                  handleValidationChange("complement", undefined);
+                }
+              }}
             />
           </div>
 
           <InputField
-            label="Complemento (opcional)"
+            label={`Complemento ${isComplementRequired ? "" : "(opcional)"}`}
             type="text"
             placeholder="Digite o complemento"
+            value={address.complement}
+            onChange={(v) => updateNested("address", { complement: v })}
+            required={isComplementRequired}
+            onValidationChange={(err) =>
+              handleValidationChange("complement", err)
+            }
+            errorMessage={validationErrors.complement}
           />
         </form>
+
         <div className="flex flex-col justify-center items-center gap-4 mt-3">
-          <PrimaryButton text="Próximo" onClick={onNext} />
+          <PrimaryButton
+            type="submit"
+            text="Próximo"
+            onClick={handleSubmit}
+            isDisabled={!isFormValid}
+          />
           <SecondaryButton text="Voltar" onClick={onBack} />
         </div>
       </div>

--- a/src/app/client-register/components/ChoosePasswordForm/index.tsx
+++ b/src/app/client-register/components/ChoosePasswordForm/index.tsx
@@ -3,19 +3,92 @@
 import PrimaryButton from "@/components/Buttons/PrimaryButton";
 import SecondaryButton from "@/components/Buttons/SecondaryButton";
 import InputField from "@/components/InputField";
-import React from "react";
+import React, { useMemo } from "react";
+import { isRequired } from "@/utils/inputs-validation";
+import { useRegister } from "../../context/RegisterContext";
 
 type ChoosePasswordFormProps = {
   onNext: () => void;
   onBack: () => void;
 };
 
+interface FieldErrors {
+  password?: string;
+  confirmPassword?: string;
+}
+
+const validatePasswordMatch = (
+  password: string,
+  confirm: string
+): string | undefined => {
+  if (confirm && password !== confirm) {
+    return "As senhas não correspondem.";
+  }
+  return undefined;
+};
+
 export default function ChoosePasswordForm({
   onNext,
   onBack,
 }: ChoosePasswordFormProps) {
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const { data, updateNested } = useRegister();
+
+  const password = data.security.password || "";
+  const confirmPassword = data.security.confirmPassword || "";
+
+  const [validationErrors, setValidationErrors] = React.useState<FieldErrors>(
+    {}
+  );
+
+  const handleValidationChange = (
+    field: keyof FieldErrors,
+    error: string | undefined
+  ) => {
+    setValidationErrors((prev) => ({
+      ...prev,
+      [field]: error,
+    }));
+  };
+
+  const validateField = (
+    field: "password" | "confirmPassword",
+    value: string
+  ) => {
+    if (field === "password") {
+      const error = isRequired(value);
+      handleValidationChange("password", error);
+
+      // Quando a senha muda, revalidar o confirm
+      if (confirmPassword) {
+        const confirmError = validatePasswordMatch(value, confirmPassword);
+        handleValidationChange("confirmPassword", confirmError);
+      }
+    }
+
+    if (field === "confirmPassword") {
+      const requiredError = isRequired(value);
+      if (requiredError) {
+        handleValidationChange("confirmPassword", requiredError);
+      } else {
+        const matchError = validatePasswordMatch(password, value);
+        handleValidationChange("confirmPassword", matchError);
+      }
+    }
+  };
+
+  const isFormValid = useMemo(() => {
+    const hasErrors = Object.values(validationErrors).some(Boolean);
+
+    return (
+      !hasErrors &&
+      password.trim().length > 0 &&
+      confirmPassword.trim().length > 0 &&
+      password === confirmPassword
+    );
+  }, [password, confirmPassword, validationErrors]);
+
+  const handleSubmit = () => {
+    if (!isFormValid) return;
     onNext();
   };
 
@@ -28,22 +101,49 @@ export default function ChoosePasswordForm({
           caractere especial.
         </p>
       </div>
+
       <div className="flex flex-col gap-6">
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <InputField
             label="Senha"
             type="password"
             placeholder="Digite a senha"
+            value={password}
+            onChange={(v) => {
+              updateNested("security", { password: v });
+              validateField("password", v);
+            }}
+            required
+            errorMessage={validationErrors.password}
           />
 
           <InputField
             label="Confirme a senha"
             type="password"
             placeholder="Confirme a senha"
+            value={confirmPassword}
+            onChange={(v) => {
+              updateNested("security", { confirmPassword: v });
+              validateField("confirmPassword", v);
+            }}
+            required
+            errorMessage={validationErrors.confirmPassword}
+            error={!!validationErrors.confirmPassword}
+            isSuccess={
+              !validationErrors.confirmPassword &&
+              confirmPassword.length > 0 &&
+              password === confirmPassword
+            }
           />
         </form>
+
         <div className="flex flex-col justify-center items-center gap-4 mt-3">
-          <PrimaryButton text="Próximo" onClick={onNext} />
+          <PrimaryButton
+            type="submit"
+            text="Próximo"
+            onClick={handleSubmit}
+            isDisabled={!isFormValid}
+          />
           <SecondaryButton text="Voltar" onClick={onBack} />
         </div>
       </div>

--- a/src/app/client-register/components/EmergencyForm/index.tsx
+++ b/src/app/client-register/components/EmergencyForm/index.tsx
@@ -7,19 +7,57 @@ import CountryCodeSelect from "@/components/CountryCodeSelect";
 import InputField from "@/components/InputField";
 import SelectInput from "@/components/SelectInput";
 import { relationshipOptions } from "@/utils/relate-degree-values";
+import { formatPhone } from "@/utils/input-formatting";
+import { validatePhone, isRequired } from "@/utils/inputs-validation";
+import { useRegister } from "../../context/RegisterContext";
 
 type EmergencyFormProps = {
   onNext: () => void;
   onBack: () => void;
 };
 
-export default function EmergencyForm({ onNext, onBack }: EmergencyFormProps) {
-  const [countryCode, setCountryCode] = React.useState("+55");
-  const [relationship, setRelationship] = React.useState("");
+interface FieldErrors {
+  contactName?: string;
+  relationship?: string;
+  phone?: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onNext();
+export default function EmergencyForm({ onNext, onBack }: EmergencyFormProps) {
+  const { data, updateNested } = useRegister();
+
+  const formRef = React.useRef<HTMLFormElement>(null);
+  const [validationErrors, setValidationErrors] = React.useState<FieldErrors>(
+    {}
+  );
+
+  const emergency = data.emergency;
+
+  const isFormValid = React.useMemo(() => {
+    const hasErrors = Object.values(validationErrors).some(Boolean);
+
+    const requiredFilled =
+      emergency.contactName.trim() !== "" &&
+      emergency.relationship.trim() !== "" &&
+      emergency.phone.trim() !== "";
+
+    return !hasErrors && requiredFilled;
+  }, [validationErrors, emergency]);
+
+  const handleValidationChange = (
+    field: keyof FieldErrors,
+    error: string | undefined
+  ) => {
+    setValidationErrors((prev) => ({ ...prev, [field]: error }));
+  };
+
+  const handleSubmit = () => {
+    formRef.current?.reportValidity();
+
+    if (isFormValid) {
+      onNext();
+    } else {
+      console.log("Formulário de Emergência inválido:", validationErrors);
+    }
   };
 
   return (
@@ -27,41 +65,76 @@ export default function EmergencyForm({ onNext, onBack }: EmergencyFormProps) {
       <div className="flex flex-col gap-2">
         <h1 className="text-2xl font-bold text-black">Contato de emergência</h1>
         <p className="text-lg lg:text-xs 2xl:text-sm">
-          Em caso de emergência, entraremos em contato com alguém que você confia.
+          Em caso de emergência, entraremos em contato com alguém que você
+          confia.
         </p>
       </div>
+
       <div className="flex flex-col gap-6">
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        <form
+          ref={formRef}
+          onSubmit={(e) => e.preventDefault()}
+          className="flex flex-col gap-6"
+        >
           <InputField
             label="Nome do contato de emergência"
             placeholder="Digite o nome do contato"
+            value={emergency.contactName}
+            onChange={(v) => updateNested("emergency", { contactName: v })}
+            required
+            onValidationChange={(err) =>
+              handleValidationChange("contactName", err)
+            }
+            errorMessage={validationErrors.contactName}
           />
 
+          {/* Parentesco */}
           <SelectInput
             label="Parentesco do contato de emergência"
-            value={relationship}
+            value={emergency.relationship}
             options={relationshipOptions}
-            onChange={setRelationship}
+            onChange={(v) => updateNested("emergency", { relationship: v })}
+            required
+            customValidator={isRequired}
+            onValidationChange={(err) =>
+              handleValidationChange("relationship", err)
+            }
+            errorMessage={validationErrors.relationship}
           />
 
+          {/* Telefone */}
           <div className="flex w-full flex-row gap-4">
             <CountryCodeSelect
               width="fit"
               label="Código do país"
-              value={countryCode}
-              onChange={setCountryCode}
+              value={emergency.countryCode}
+              onChange={(v) => updateNested("emergency", { countryCode: v })}
             />
 
             <InputField
               className="w-full"
               label="Número de telefone"
               type="tel"
-              placeholder="(XXX) XXX-XXXX"
+              placeholder="(XX) XXXXX-XXXX"
+              value={emergency.phone}
+              onChange={(v) =>
+                updateNested("emergency", { phone: formatPhone(v) })
+              }
+              required
+              customValidator={validatePhone}
+              onValidationChange={(err) => handleValidationChange("phone", err)}
+              errorMessage={validationErrors.phone}
             />
           </div>
         </form>
+
         <div className="flex flex-col justify-center items-center gap-4 mt-3">
-          <PrimaryButton text="Próximo" onClick={onNext} />
+          <PrimaryButton
+            type="submit"
+            text="Próximo"
+            onClick={handleSubmit}
+            isDisabled={!isFormValid}
+          />
           <SecondaryButton text="Voltar" onClick={onBack} />
         </div>
       </div>

--- a/src/app/client-register/components/PersonalDataForm/index.tsx
+++ b/src/app/client-register/components/PersonalDataForm/index.tsx
@@ -7,6 +7,7 @@ import InputField from "@/components/InputField";
 import { formatCpf, formatPhone } from "@/utils/input-formatting";
 import { validateCpf, validatePhone } from "@/utils/inputs-validation";
 import React from "react";
+import { useRegister } from "../../context/RegisterContext";
 
 type PersonalDataFormProps = {
   onNext: () => void;
@@ -24,50 +25,42 @@ export default function PersonalDataForm({
   onNext,
   onBack,
 }: PersonalDataFormProps) {
-  const [name, setName] = React.useState("");
-  const [cpf, setCpf] = React.useState("");
-  const [birthdate, setBirthdate] = React.useState("");
-  const [phone, setPhone] = React.useState("");
-  const [countryCode, setCountryCode] = React.useState("+55");
+  const { data, updateNested } = useRegister();
 
-  const [validationErrors, setValidationErrors] = React.useState<FieldErrors>({});
-  
+  const [validationErrors, setValidationErrors] = React.useState<FieldErrors>(
+    {}
+  );
+  const formRef = React.useRef<HTMLFormElement>(null);
+
   const isFormValid = React.useMemo(() => {
-    const hasErrors = Object.values(validationErrors).some((error) => !!error);
+    const hasErrors = Object.values(validationErrors).some(Boolean);
 
     const allRequiredFieldsFilled =
-      name.trim() !== "" &&
-      cpf.trim() !== "" &&
-      birthdate.trim() !== "" &&
-      phone.trim() !== "";
+      data.personal.name.trim() !== "" &&
+      data.personal.cpf.trim() !== "" &&
+      data.personal.birthdate.trim() !== "" &&
+      data.personal.phone.trim() !== "";
 
-    return !hasErrors && allRequiredFieldsFilled; 
-  }, [validationErrors, name, cpf, birthdate, phone]);
-
+    return !hasErrors && allRequiredFieldsFilled;
+  }, [validationErrors, data]);
 
   const handleValidationChange = (
     fieldName: keyof FieldErrors,
     error: string | undefined
   ) => {
-    setValidationErrors((prevErrors) => ({
-      ...prevErrors,
+    setValidationErrors((prev) => ({
+      ...prev,
       [fieldName]: error,
     }));
   };
-  
-  const formRef = React.useRef<HTMLFormElement>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    if (formRef.current) {
-        formRef.current.reportValidity();
-    }
-    
+  const handleSubmit = () => {
+    if (formRef.current) formRef.current.reportValidity();
+
     if (isFormValid) {
-        onNext();
+      onNext();
     } else {
-        console.log("Formulário inválido. Erros:", validationErrors);
+      console.log("Formulário inválido. Erros:", validationErrors);
     }
   };
 
@@ -81,21 +74,20 @@ export default function PersonalDataForm({
           Insira os seus dados de identificação e contato.
         </p>
       </div>
+
       <div className="flex flex-col gap-6 lg:gap-5 2xl:gap-7">
         <form
           ref={formRef}
-          onSubmit={handleSubmit}
+          onSubmit={(e) => e.preventDefault()}
           className="flex flex-col gap-6 lg:gap-5 2xl:gap-5"
         >
           <InputField
             label="Nome completo"
             placeholder="Digite seu nome completo"
-            value={name}
-            onChange={setName}
-            required={true}
-            onValidationChange={(error) =>
-              handleValidationChange("name", error)
-            }
+            value={data.personal.name}
+            onChange={(v) => updateNested("personal", { name: v })}
+            required
+            onValidationChange={(err) => handleValidationChange("name", err)}
             errorMessage={validationErrors.name}
           />
 
@@ -105,24 +97,27 @@ export default function PersonalDataForm({
               label="CPF"
               type="text"
               placeholder="Digite seu CPF"
-              value={cpf}
-              onChange={(newValue) => setCpf(formatCpf(newValue))}
-              required={true}
-              customValidator={validateCpf}
-              onValidationChange={(error) =>
-                handleValidationChange("cpf", error)
+              value={data.personal.cpf}
+              onChange={(v) =>
+                updateNested("personal", { cpf: formatCpf(v) })
               }
+              required
+              customValidator={validateCpf}
+              onValidationChange={(err) => handleValidationChange("cpf", err)}
               errorMessage={validationErrors.cpf}
             />
+
             <InputField
               className="w-full"
               label="Data de nascimento"
               type="date"
-              value={birthdate}
-              onChange={setBirthdate}
-              required={true}
-              onValidationChange={(error) =>
-                handleValidationChange("birthdate", error)
+              value={data.personal.birthdate}
+              onChange={(v) =>
+                updateNested("personal", { birthdate: v })
+              }
+              required
+              onValidationChange={(err) =>
+                handleValidationChange("birthdate", err)
               }
               errorMessage={validationErrors.birthdate}
             />
@@ -132,8 +127,10 @@ export default function PersonalDataForm({
             <CountryCodeSelect
               width="fit"
               label="Código do país"
-              value={countryCode}
-              onChange={setCountryCode}
+              value={data.personal.countryCode}
+              onChange={(v) =>
+                updateNested("personal", { countryCode: v })
+              }
             />
 
             <InputField
@@ -141,22 +138,23 @@ export default function PersonalDataForm({
               label="Número de telefone"
               type="tel"
               placeholder="(XX) XXXXX-XXXX"
-              value={phone}
-              onChange={(newValue) => setPhone(formatPhone(newValue))}
-              required={true}
-              customValidator={validatePhone}
-              onValidationChange={(error) =>
-                handleValidationChange("phone", error)
+              value={data.personal.phone}
+              onChange={(v) =>
+                updateNested("personal", { phone: formatPhone(v) })
               }
+              required
+              customValidator={validatePhone}
+              onValidationChange={(err) => handleValidationChange("phone", err)}
               errorMessage={validationErrors.phone}
             />
           </div>
         </form>
+
         <div className="flex flex-col justify-center items-center gap-3 mt-3">
           <PrimaryButton
             type="submit"
             text="Próximo"
-            onClick={() => handleSubmit}
+            onClick={handleSubmit}
             isDisabled={!isFormValid}
           />
           <SecondaryButton text="Voltar" onClick={onBack} />

--- a/src/app/client-register/components/WelcomeStep/index.tsx
+++ b/src/app/client-register/components/WelcomeStep/index.tsx
@@ -5,32 +5,29 @@
 import React from "react";
 import PrimaryButton from "@/components/Buttons/PrimaryButton";
 import InputField from "@/components/InputField";
+import { useRegister } from "../../context/RegisterContext";
 
 type WelcomeStepProps = {
   onNext: () => void;
 };
 
 export default function WelcomeStep({ onNext }: WelcomeStepProps) {
-  const [email, setEmail] = React.useState("");
+  const { data, update } = useRegister();
+
   const [emailValidationError, setEmailValidationError] = React.useState<
     string | undefined
   >(undefined);
   const [submitted, setSubmitted] = React.useState(false);
 
-  const isFormValid = !emailValidationError && email.length > 0;
+  const isFormValid = !emailValidationError && data.email.trim().length > 0;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
     setSubmitted(true);
 
     if (isFormValid) {
       onNext();
     }
-  };
-
-  const handleEmailValidation = (error: string | undefined) => {
-    setEmailValidationError(error);
   };
 
   return (
@@ -44,6 +41,7 @@ export default function WelcomeStep({ onNext }: WelcomeStepProps) {
           bem-estar.
         </p>
       </div>
+
       <form
         onSubmit={handleSubmit}
         className="flex flex-col gap-4 lg:gap-2.5 2xl:gap-5"
@@ -52,13 +50,14 @@ export default function WelcomeStep({ onNext }: WelcomeStepProps) {
           label="E-mail"
           type="email"
           placeholder="Digite seu e-mail"
-          value={email}
-          onChange={setEmail}
-          required={true}
+          value={data.email}
+          onChange={(v) => update({ email: v })}
+          required
           shouldValidate={submitted}
-          onValidationChange={handleEmailValidation}
+          onValidationChange={setEmailValidationError}
           errorMessage={submitted ? emailValidationError : undefined}
         />
+
         <div className="flex flex-col justify-center items-center gap-15 mt-3">
           <div className="flex flex-col gap-4 w-full">
             <PrimaryButton
@@ -79,6 +78,7 @@ export default function WelcomeStep({ onNext }: WelcomeStepProps) {
               da Pulsar.
             </p>
           </div>
+
           <span className="lg:text-xs 2xl:text text-lg">
             Já possui uma conta?{" "}
             <a href="/login" className="text-blue font-semibold underline">

--- a/src/app/client-register/context/RegisterContext.tsx
+++ b/src/app/client-register/context/RegisterContext.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+
+type RegisterData = {
+  email: string;
+  personal: {
+    name: string;
+    cpf: string;
+    birthdate: string;
+    phone: string;
+    countryCode: string;
+  };
+  emergency: {
+    contactName: string;
+    relationship: string;
+    phone: string;
+    countryCode: string;
+  };
+  address: {
+    zipCode: string;
+    countryName: string;
+    state: string;
+    city: string;
+    district: string;
+    street: string;
+    number: string;
+    complement: string;
+    noNumber: boolean;
+  };
+  security: {
+    password: string;
+    confirmPassword: string;
+  };
+};
+
+type OnlyObjectKeys<T> = {
+  [K in keyof T]: T[K] extends object
+    ? T[K] extends any[]
+      ? never
+      : K
+    : never;
+}[keyof T];
+
+type RegisterContextType = {
+  data: RegisterData;
+
+  /** update global */
+  update: (patch: Partial<RegisterData>) => void;
+
+  /** update nested (somente objetos) */
+  updateNested: <K extends OnlyObjectKeys<RegisterData>>(
+    key: K,
+    patch: Partial<RegisterData[K]>
+  ) => void;
+};
+
+const defaultValue: RegisterData = {
+  email: "",
+  personal: {
+    name: "",
+    cpf: "",
+    birthdate: "",
+    phone: "",
+    countryCode: "+55",
+  },
+  emergency: {
+    contactName: "",
+    relationship: "",
+    phone: "",
+    countryCode: "+55",
+  },
+  address: {
+    zipCode: "",
+    countryName: "brazil",
+    state: "",
+    city: "",
+    district: "",
+    street: "",
+    number: "",
+    complement: "",
+    noNumber: false,
+  },
+  security: {
+    password: "",
+    confirmPassword: "",
+  },
+};
+
+const RegisterContext = createContext<RegisterContextType | null>(null);
+
+export function RegisterProvider({ children }: { children: React.ReactNode }) {
+  const [data, setData] = useState<RegisterData>(defaultValue);
+
+  function update(patch: Partial<RegisterData>) {
+    setData((prev) => ({ ...prev, ...patch }));
+  }
+
+  function updateNested<K extends OnlyObjectKeys<RegisterData>>(
+    key: K,
+    patch: Partial<RegisterData[K]>
+  ) {
+    setData((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], ...patch },
+    }));
+  }
+
+  return (
+    <RegisterContext.Provider value={{ data, update, updateNested }}>
+      {children}
+    </RegisterContext.Provider>
+  );
+}
+
+export function useRegister() {
+  const ctx = useContext(RegisterContext);
+  if (!ctx) throw new Error("useRegister must be used inside RegisterProvider");
+  return ctx;
+}

--- a/src/app/client-register/controller/index.controller.tsx
+++ b/src/app/client-register/controller/index.controller.tsx
@@ -1,53 +1,92 @@
-// src/app/register/controller/index.controller.tsx
-
 "use client";
 
 import React, { JSX } from "react";
 import ClientRegisterView from "../view/index.view";
-import WelcomeStep from "../components/WelcomeStep"; // << NOVO COMPONENTE
-import PersonalDataForm from "../components/PersonalDataForm"; // << AGORA STEP 2
+import WelcomeStep from "../components/WelcomeStep";
+import PersonalDataForm from "../components/PersonalDataForm";
 import EmergencyForm from "../components/EmergencyForm";
 import AddressForm from "../components/AddressForm";
 import ChoosePasswordForm from "../components/ChoosePasswordForm";
+import { RegisterProvider } from "../context/RegisterContext";
+import SpinnerLoading from "@/components/SpinnerLoading";
+
+type Step = 1 | 2 | 3 | 4 | 5;
+const STORAGE_KEY = "register_step";
+
+function clampStep(n: number): Step {
+  if (n < 1) return 1;
+  if (n > 5) return 5;
+  return n as Step;
+}
 
 export default function ClientRegisterController() {
-  const [step, setStep] = React.useState(1);
+  const [step, setStep] = React.useState<Step | null>(null);
 
   React.useEffect(() => {
-    const stored = history.state?.step;
+    try {
+      const fromStorage = sessionStorage.getItem(STORAGE_KEY);
 
-    if (typeof stored === "number") {
-      setStep(stored);
-    } else {
+      if (fromStorage) {
+        const parsed = Number(fromStorage);
+        if (!Number.isNaN(parsed)) {
+          const s = clampStep(parsed);
+          setStep(s);
+
+          history.replaceState({ step: s }, "");
+          return;
+        }
+      }
+
+      const fromHistory = history.state?.step;
+
+      if (typeof fromHistory === "number") {
+        const s = clampStep(fromHistory);
+        setStep(s);
+        return;
+      }
+
       history.replaceState({ step: 1 }, "");
+      setStep(1);
+    } catch {
+      history.replaceState({ step: 1 }, "");
+      setStep(1);
     }
   }, []);
 
   React.useEffect(() => {
-    const handlePop = (event: PopStateEvent) => {
-      const s = event.state?.step;
+    const onPop = (ev: PopStateEvent) => {
+      const newStep = ev.state?.step;
 
-      if (typeof s === "number") {
+      if (typeof newStep === "number") {
+        const s = clampStep(newStep);
         setStep(s);
+
+        try {
+          sessionStorage.setItem(STORAGE_KEY, String(s));
+        } catch {}
       }
     };
 
-    window.addEventListener("popstate", handlePop);
-    return () => window.removeEventListener("popstate", handlePop);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  const goToStep = (newStep: number) => {
-    const totalSteps = Object.keys(steps).length;
-    if (newStep >= 1 && newStep <= totalSteps) {
-      setStep(newStep);
-      history.pushState({ step: newStep }, "");
+  const goToStep = (newStepNumber: number) => {
+    const s = clampStep(newStepNumber);
+    setStep(s);
+
+    try {
+      history.pushState({ step: s }, "");
+      sessionStorage.setItem(STORAGE_KEY, String(s));
+    } catch {
+      history.pushState({ step: s }, "");
     }
   };
 
-  const handleNext = () => goToStep(step + 1);
-  const handleBack = () => goToStep(step - 1);
+  const handleNext = () => step && goToStep(step + 1);
+  const handleBack = () => step && goToStep(step - 1);
 
-  const steps: Record<number, JSX.Element> = {
+  const steps: Record<Step, JSX.Element> = {
     1: <WelcomeStep onNext={handleNext} />,
     2: <PersonalDataForm onNext={handleNext} onBack={handleBack} />,
     3: <EmergencyForm onNext={handleNext} onBack={handleBack} />,
@@ -55,7 +94,7 @@ export default function ClientRegisterController() {
     5: <ChoosePasswordForm onNext={handleNext} onBack={handleBack} />,
   };
 
-  const stepTitles: string[] = [
+  const stepTitles = [
     "Cadastro",
     "Dados Pessoais",
     "Contato de Emergência",
@@ -64,14 +103,22 @@ export default function ClientRegisterController() {
     "Conclusão",
   ];
 
-  const totalSteps = Object.keys(steps).length;
+  if (step === null) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <SpinnerLoading />
+      </div>
+    );
+  }
 
   return (
-    <ClientRegisterView
-      stepComponent={steps[step]}
-      currentStep={step}
-      totalSteps={totalSteps}
-      stepTitles={stepTitles}
-    />
+    <RegisterProvider>
+      <ClientRegisterView
+        stepComponent={steps[step]}
+        currentStep={step}
+        totalSteps={5}
+        stepTitles={stepTitles}
+      />
+    </RegisterProvider>
   );
 }

--- a/src/components/InputField/index.tsx
+++ b/src/components/InputField/index.tsx
@@ -34,6 +34,7 @@ type InputFieldProps = {
   onValidationChange?: (error: string | undefined) => void;
   className?: string;
   shouldValidate?: boolean;
+  isSuccess?: boolean;
 };
 
 const InputField = ({
@@ -49,6 +50,7 @@ const InputField = ({
   customValidator,
   onValidationChange,
   shouldValidate = false,
+  isSuccess = false,
   className,
 }: InputFieldProps) => {
   const [validationError, setValidationError] = React.useState<
@@ -112,7 +114,7 @@ const InputField = ({
     const newValue = e.target.value;
     onChange?.(newValue);
 
-    if (shouldValidate) {
+    if (isError || touched || shouldValidate) {
       validateField(newValue);
     }
   };
@@ -137,7 +139,9 @@ const InputField = ({
           ${
             isError
               ? "border-red-500 focus:border-red-600"
-              : "border-gray-light focus:border-blue"
+              : isSuccess 
+                ? "border-green-500 focus:border-green-600"
+                : "border-gray-light focus:border-blue"
           }
         `}
         placeholder={placeholder}

--- a/src/components/SelectInput/index.tsx
+++ b/src/components/SelectInput/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
+type ValidatorType = (value: string | undefined) => string | undefined;
 
 type SelectInputProps = {
   label?: string;
@@ -6,9 +7,20 @@ type SelectInputProps = {
   value?: string | number;
   isDisabled?: boolean;
   onChange?: (value: string) => void;
-  error?: boolean;
   className?: string;
   width?: "fit" | "full";
+
+  required?: boolean;
+  customValidator?: ValidatorType;
+  onValidationChange?: (error: string | undefined) => void;
+  errorMessage?: string;
+};
+
+const isRequiredValidator: ValidatorType = (value) => {
+  if (!value || String(value).trim() === "") {
+    return "Este campo é obrigatório.";
+  }
+  return undefined;
 };
 
 export default function SelectInput({
@@ -17,24 +29,95 @@ export default function SelectInput({
   value,
   isDisabled = false,
   onChange,
-  error = false,
   className,
   width = "full",
+  required = false,
+  customValidator,
+  onValidationChange,
+  errorMessage,
 }: SelectInputProps) {
-  const [open, setOpen] = useState(false);
+  const selectRef = React.useRef<HTMLDivElement>(null);
+
+  const [open, setOpen] = React.useState(false);
+  const [touched, setTouched] = React.useState(false);
+  const [validationError, setValidationError] = React.useState<
+    string | undefined
+  >(undefined);
 
   const selected = options.find((option) => option.value === value);
   const widthClass = width === "fit" ? "inline-flex flex-col w-fit" : "w-full";
 
+  const validateField = (currentValue: string | undefined) => {
+    let error: string | undefined;
+    if (required) {
+      error = isRequiredValidator(currentValue);
+    }
+    if (!error && customValidator) {
+      const val = currentValue !== undefined ? String(currentValue) : undefined;
+      error = customValidator(val);
+    }
+    setValidationError(error);
+    onValidationChange?.(error);
+  };
+
+  React.useEffect(() => {
+    if (touched) {
+      validateField(value !== undefined ? String(value) : undefined);
+    }
+  }, [value, touched, required, customValidator]);
+
+  const finalErrorMsg = errorMessage || (touched ? validationError : undefined);
+  const hasError = !!finalErrorMsg;
+
+  // const handleBlur = () => {
+  //   if (open) return;
+
+  //   if (!touched) {
+  //     setTouched(true);
+  //   }
+  //   validateField(value !== undefined ? String(value) : undefined);
+  // };
+
+  const handleSelect = (selectedValue: string) => {
+    onChange?.(selectedValue);
+    setOpen(false);
+    setTouched(true);
+  };
+
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        selectRef.current &&
+        !selectRef.current.contains(event.target as Node)
+      ) {
+        if (open) {
+          setOpen(false);
+          setTouched(true);
+          validateField(value !== undefined ? String(value) : undefined);
+        }
+      }
+    };
+
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open, value, required, customValidator]);
+
   return (
-    <div className={`relative ${widthClass} ${className || ""}`}>
+    <div
+      ref={selectRef}
+      className={`relative ${widthClass} ${className || ""}`}
+    >
       {label && (
         <label className="block text-md font-medium mb-2 text-black">
           {label}
         </label>
       )}
 
-      {/* Botão principal */}
       <button
         type="button"
         disabled={isDisabled}
@@ -45,7 +128,7 @@ export default function SelectInput({
         }}
         className={`flex items-center justify-between w-full border rounded px-3 py-3 bg-blue-lightest text-left focus:outline-none
           ${
-            error
+            hasError
               ? "border-red-500 focus:border-red-600"
               : "border-gray-light focus:border-blue"
           }
@@ -61,22 +144,22 @@ export default function SelectInput({
         <span className="text-gray ml-2">▾</span>
       </button>
 
-      {/* Dropdown */}
       {open && !isDisabled && (
-        <ul className="absolute z-10 mt-1 w-full max-h-56 overflow-y-auto bg-white border border-gray-light rounded shadow-lg">
+        <ul className="absolute z-20 mt-1 w-full max-h-56 overflow-y-auto bg-white border border-gray-light rounded shadow-lg">
           {options.map((option) => (
             <li
               key={option.value}
               className="px-3 py-2 hover:bg-blue-lightest cursor-pointer text-black"
-              onClick={() => {
-                onChange?.(option.value);
-                setOpen(false);
-              }}
+              onClick={() => handleSelect(option.value)}
             >
               {option.label}
             </li>
           ))}
         </ul>
+      )}
+
+      {finalErrorMsg && (
+        <p className="mt-1 text-sm text-red-500">{finalErrorMsg}</p>
       )}
     </div>
   );

--- a/src/components/SpinnerLoading/index.tsx
+++ b/src/components/SpinnerLoading/index.tsx
@@ -1,0 +1,20 @@
+import { Oval } from 'react-loader-spinner'
+
+function SpinnerLoading() {
+  return (
+    <Oval
+      height={80}
+      width={80}
+      color="#3852E7"
+      wrapperStyle={{}}
+      wrapperClass=""
+      visible={true}
+      ariaLabel='oval-loading'
+      secondaryColor="#3852E7"
+      strokeWidth={2}
+      strokeWidthSecondary={2}
+    />
+  )
+}
+
+export default SpinnerLoading;

--- a/src/utils/input-formatting.ts
+++ b/src/utils/input-formatting.ts
@@ -1,33 +1,45 @@
 // src/utils/input-formatting.ts
 
 const cleanNumber = (value: string | undefined): string => {
-    return value ? value.replace(/\D/g, '') : '';
+  return value ? value.replace(/\D/g, "") : "";
 };
 
 export const formatCpf = (value: string | undefined): string => {
-    const cleaned = cleanNumber(value).substring(0, 11);
-    if (cleaned.length > 9) {
-        return cleaned.replace(/^(\d{3})(\d{3})(\d{3})(\d{2})$/, '$1.$2.$3-$4');
-    }
-    if (cleaned.length > 6) {
-        return cleaned.replace(/^(\d{3})(\d{3})(\d{3})$/, '$1.$2.$3');
-    }
-    if (cleaned.length > 3) {
-        return cleaned.replace(/^(\d{3})(\d{3})$/, '$1.$2');
-    }
-    return cleaned;
+  const cleaned = cleanNumber(value).substring(0, 11);
+  if (cleaned.length > 9) {
+    return cleaned.replace(/^(\d{3})(\d{3})(\d{3})(\d{2})$/, "$1.$2.$3-$4");
+  }
+  if (cleaned.length > 6) {
+    return cleaned.replace(/^(\d{3})(\d{3})(\d{3})$/, "$1.$2.$3");
+  }
+  if (cleaned.length > 3) {
+    return cleaned.replace(/^(\d{3})(\d{3})$/, "$1.$2");
+  }
+  return cleaned;
 };
 
 export const formatPhone = (value: string | undefined): string => {
-    const cleaned = cleanNumber(value).substring(0, 11); // Max 11 digitos
-    if (cleaned.length > 10) {
-        return cleaned.replace(/^(\d{2})(\d{5})(\d{4})$/, '($1) $2-$3');
-    }
-    if (cleaned.length > 6) {
-        return cleaned.replace(/^(\d{2})(\d{4})(\d{4})$/, '($1) $2-$3');
-    }
-    if (cleaned.length > 2) {
-        return cleaned.replace(/^(\d{2})(\d+)$/, '($1) $2');
-    }
-    return cleaned;
+  const cleaned = cleanNumber(value).substring(0, 11); // Max 11 digitos
+  if (cleaned.length > 10) {
+    return cleaned.replace(/^(\d{2})(\d{5})(\d{4})$/, "($1) $2-$3");
+  }
+  if (cleaned.length > 6) {
+    return cleaned.replace(/^(\d{2})(\d{4})(\d{4})$/, "($1) $2-$3");
+  }
+  if (cleaned.length > 2) {
+    return cleaned.replace(/^(\d{2})(\d+)$/, "($1) $2");
+  }
+  return cleaned;
+};
+
+export const formatCEP = (value: string): string => {
+  const numericValue = value.replace(/\D/g, "");
+
+  const cep = numericValue.substring(0, 8);
+
+  if (cep.length === 8) {
+    return cep.replace(/^(\d{5})(\d{3})$/, "$1-$2");
+  }
+
+  return cep;
 };

--- a/src/utils/inputs-validation.ts
+++ b/src/utils/inputs-validation.ts
@@ -22,9 +22,22 @@ export const validateEmail: Validator = (value) => {
 };
 
 export const validatePassword: Validator = (value) => {
-  if (value && value.length < 8) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value.length < 8) {
     return "A senha deve ter no mínimo 8 caracteres.";
   }
+
+  const passwordRegex = new RegExp(
+    /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()-+_])[A-Za-z\d!@#$%^&*()-+_]{8,}$/
+  );
+
+  if (!passwordRegex.test(value)) {
+    return "A senha deve conter letras, números e um caractere especial (ex: !, @, #, $).";
+  }
+
   return undefined;
 };
 
@@ -95,5 +108,23 @@ export const runValidators = (
       return error;
     }
   }
+  return undefined;
+};
+
+export const validateCEP: Validator = (value) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const digits = String(value).replace(/\D/g, "");
+
+  if (digits.length < 8) {
+    return "O CEP deve ter 8 dígitos.";
+  }
+
+  if (!/^\d{5}-?\d{3}$/.test(value)) {
+    return "Formato de CEP inválido.";
+  }
+
   return undefined;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
### Summary

- Persist client registration step across reloads/history navigation and show a spinner while bootstrapping.
- Add shared validation and formatting utilities (CPF/CEP/phone/email/password, required checks, runners) and wire them through the step forms.
- Improve Input/Select components to surface validation state upstream, gating step navigation.

### Changes

- **[index.controller.tsx](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — clamp and persist steps via sessionStorage/history; guard navigation; wrap flow in RegisterProvider; show full-screen SpinnerLoading while resolving the initial step.
- [**index.tsx](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — new branded loader using react-loader-spinner.
- **[inputs-validation.ts](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — validators for required, email, password strength, number, CPF (with checksum), phone (10/11 digits), CEP, plus [runValidators](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- **[input-formatting.ts](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — masking helpers for CPF, phone, CEP (8-digit with hyphen).
- **[index.tsx](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — runs default + custom validators, tracks touched/forced validation, and reports errors to parents so steps can block progression.
- **[index.tsx](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — required/custom validation, touched tracking, and outside-click closing with error surfacing.

- **Step forms:**
- [x] **[PersonalDataForm](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — masks CPF/phone, validates CPF/phone/required fields, and gates “Próximo”.
- [x] **[EmergencyForm](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — required select + phone validation/masking, country code support.
- [x] **[AddressForm](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — CEP mask/validation, required address fields, conditional number/complement handling, country selection.
- [x] **[ChoosePasswordForm](vscode-file://vscode-app/c:/Users/rebeca.oliveira/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)** — required password/confirm with match checks and inline success/error states.